### PR TITLE
Handle url parse error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ vendor/
 # tmp not commited folders with dev info
 examples/
 docs/
+.idea/

--- a/client.go
+++ b/client.go
@@ -75,7 +75,10 @@ func (c *HuaweiClient) GetToken() string {
 }
 
 func (c *HuaweiClient) requestToken(ctx context.Context) (string, error) {
-	u, _ := url.Parse(c.appSecret)
+	u, err := url.Parse(c.appSecret)
+	if err != nil {
+		return "", err
+	}
 	body := fmt.Sprintf("grant_type=client_credentials&client_secret=%s&client_id=%s", u.String(), c.appId)
 
 	request := NewHTTPRequest().


### PR DESCRIPTION
In case of an invalid token being provided, the url parsing fails and gives back nil.
calling u.String() afterwards panics. So the error should be handled previously.